### PR TITLE
Config tweak

### DIFF
--- a/Framework/Configuration/Settings.cs
+++ b/Framework/Configuration/Settings.cs
@@ -22,5 +22,6 @@ namespace Framework
         public static readonly int RealmPort = Conf.GetInt("RealmPort", 8084);
         public static readonly int InstancePort = Conf.GetInt("InstancePort", 8086);
         public static readonly bool DebugOutput = Conf.GetBoolean("DebugOutput", false);
+        public static readonly bool PacketsLog = Conf.GetBoolean("PacketsLog", true);
     }
 }

--- a/HermesProxy/App.config
+++ b/HermesProxy/App.config
@@ -81,5 +81,11 @@
             Default:     "false"
     -->
     <add key="DebugOutput" value="false" />
+    <!--
+            Option:      PacketsLog
+            Description: Save each session's packets to a single file in PacketsLog directory.
+            Default:     "true"
+    -->
+    <add key="PacketsLog" value="true" />
   </appSettings>
 </configuration>

--- a/HermesProxy/App.config
+++ b/HermesProxy/App.config
@@ -5,6 +5,7 @@
             Option:      ClientBuild
             Description: The version of the client you will play with.
             Default:     "40618" (1.14.0)
+                         "40892" (2.5.2)
     -->
     <add key="ClientBuild" value="40618" />
     <!--
@@ -17,6 +18,7 @@
             Option:      ServerBuild
             Description: The version of the server you want to connect to.
             Default:     "5875" (1.12.1)
+                         "8606" (2.4.3)
     -->
     <add key="ServerBuild" value="5875" />
     <!--

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -47,6 +47,9 @@ namespace HermesProxy.World
 
         public void LogPacket(ref SniffFile sniffFile)
         {
+            if (!Framework.Settings.PacketsLog)
+                return;
+
             if (sniffFile == null)
             {
                 sniffFile = new SniffFile("modern", (ushort)Framework.Settings.ClientBuild);
@@ -100,6 +103,9 @@ namespace HermesProxy.World
 
         public void LogPacket(ref SniffFile sniffFile)
         {
+            if (!Framework.Settings.PacketsLog)
+                return;
+
             if (sniffFile == null)
             {
                 sniffFile = new SniffFile("modern", (ushort)Framework.Settings.ClientBuild);

--- a/HermesProxy/World/SniffFile.cs
+++ b/HermesProxy/World/SniffFile.cs
@@ -11,7 +11,15 @@ namespace HermesProxy.World
     {
         public SniffFile(string fileName, ushort build)
         {
-            _fileWriter = new System.IO.BinaryWriter(File.Open(fileName + "_" + build + "_" + Time.UnixTime + ".pkt", FileMode.Create));
+            string path = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            path = Path.Combine(path, "PacketsLog");
+            if (!Directory.Exists(path))
+                Directory.CreateDirectory(path);
+
+            string file = fileName + "_" + build + "_" + Time.UnixTime + ".pkt";
+            path = Path.Combine(path, file);
+
+            _fileWriter = new System.IO.BinaryWriter(File.Open(path, FileMode.Create));
             _gameVersion = build;
         }
         BinaryWriter _fileWriter;


### PR DESCRIPTION
Add tbc client build number to config comments
Make packets log optional. It takes a decent amount of space over time, and most users don't need it in my opinion.